### PR TITLE
Automatically create copybara PRs

### DIFF
--- a/.github/workflows/create-pr-copybara-sync.yml
+++ b/.github/workflows/create-pr-copybara-sync.yml
@@ -1,0 +1,25 @@
+name: "Create Copybara PR"
+
+on:
+  push:
+    branches:
+      - "copybara/sync"
+
+jobs:
+  open-pr:
+    name: "Create PR"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: copybara/sync
+
+      - name: Get git commit data
+        uses: rlespinasse/git-commit-data-action@v1
+
+      - name: Open PR
+        run: |
+          gh pr create -B main -H copybara/sync --no-maintainer-edit -t "${{ env.GIT_COMMIT_MESSAGE_SUBJECT }}" -b "${{ env.GIT_COMMIT_MESSAGE_BODY }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On every push to the `copybara/sync` branch, the PR is automatically created. This removes the need for 2 people being involved. @RogerHYang and I can still be the reviewers, but if we want to publish something (already approved in `main` branch of our monorepo) it becomes very annoying to have to bother someone else again